### PR TITLE
Unmapped reads

### DIFF
--- a/alignment/Blasr.cpp
+++ b/alignment/Blasr.cpp
@@ -3785,14 +3785,28 @@ void MapReads(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapData) {
         //
         // Print the unaligned sequences.
         //
+        if (params.printFormat == SAM) {
+          if (params.nProc == 1) {
+            SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
+          }
+          else {
+#ifdef __APPLE__
+            sem_wait(semaphores.writer);
+#else
+            sem_wait(&semaphores.writer);
+#endif
+            SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
+#ifdef __APPLE__
+            sem_post(semaphores.writer);
+#else
+            sem_post(&semaphores.writer);
+#endif
+          }
+        }
+
         if (params.printUnaligned == true) {
           if (params.nProc == 1) {
-            if (params.printFormat == SAM) {
-              SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
-            }
-            else {
-              allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
-            }
+            allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
           }
           else {
 #ifdef __APPLE__
@@ -3800,12 +3814,7 @@ void MapReads(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapData) {
 #else
             sem_wait(&semaphores.unaligned);
 #endif
-            if (params.printFormat == SAM) {
-              SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
-            }
-            else {
-              allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
-            }
+            allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
 #ifdef __APPLE__
             sem_post(semaphores.unaligned);
 #else

--- a/alignment/Blasr.cpp
+++ b/alignment/Blasr.cpp
@@ -3787,7 +3787,12 @@ void MapReads(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapData) {
         //
         if (params.printUnaligned == true) {
           if (params.nProc == 1) {
-            allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
+            if (params.printFormat == SAM) {
+              SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
+            }
+            else {
+              allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
+            }
           }
           else {
 #ifdef __APPLE__
@@ -3795,7 +3800,12 @@ void MapReads(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapData) {
 #else
             sem_wait(&semaphores.unaligned);
 #endif
-            allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
+            if (params.printFormat == SAM) {
+              SAMOutput::PrintUnalignedRead(allReadAlignments.subreads[subreadIndex], *mapData->outFilePtr, alignmentContext, params.samQVList, params.clipping);
+            }
+            else {
+              allReadAlignments.subreads[subreadIndex].PrintSeq(*mapData->unalignedFilePtr);
+            }
 #ifdef __APPLE__
             sem_post(semaphores.unaligned);
 #else

--- a/common/algorithms/alignment/printers/SAMPrinter.h
+++ b/common/algorithms/alignment/printers/SAMPrinter.h
@@ -524,7 +524,7 @@ namespace SAMOutput {
     // "XQ" query sequence length
     // "XT" # of continues reads, always 1 for blasr
     //
-    samFile << "XT:i:1\t"; // reads are allways continuous reads, not
+    samFile << "XT:i:1"; // reads are allways continuous reads, not
                         // referenced based circular consensus when
                         // output by blasr.
     // Add query sequence length

--- a/common/algorithms/alignment/printers/SAMPrinter.h
+++ b/common/algorithms/alignment/printers/SAMPrinter.h
@@ -488,6 +488,58 @@ namespace SAMOutput {
 
     alignedSequence.FreeIfControlled();
   }
+  template<typename T_Sequence>
+  void PrintUnalignedRead(T_Sequence &read,
+                      ostream &samFile,
+                      AlignmentContext &context,
+											SupplementalQVList &qvlist,
+                      Clipping clipping = none,
+                      int subreadIndex = 0,
+                      int nSubreads = 0) {
+
+    string cigarString = "*";
+    uint16_t flag = SEGMENT_UNMAPPED;
+
+    // Unmapped reads have fixed defaults for most fields.
+    samFile << read.title << "\t" << flag << "\t*\t0\t0\t*\t*\t0\t0\t";   // RNAME, POS, MAP, CIGAR, RNEXT, PNEXT, TLEN
+
+    ((DNASequence)read).PrintSeq(samFile, 0);  // SEQ
+    samFile << "\t";
+    if (read.qual.data != NULL) {
+      read.PrintAsciiQual(samFile, 0);  // QUAL
+    }
+    else {
+      samFile <<"*";
+    }
+    samFile << "\t";
+
+    //
+    // Add optional fields
+    //
+    samFile << "RG:Z:" << context.readGroupId << "\t";
+
+		// must recompute the
+    //
+    // "RG" read group Id
+    // "XQ" query sequence length
+    // "XT" # of continues reads, always 1 for blasr
+    //
+    samFile << "XT:i:1\t"; // reads are allways continuous reads, not
+                        // referenced based circular consensus when
+                        // output by blasr.
+    // Add query sequence length
+    samFile << "\t" << "XQ:i:" << read.length;
+
+		//
+		// Write out optional quality values.  If qvlist does not
+		// have any qv's signaled to print, this is a no-op.
+		//
+		// First transform characters that are too large to printable ones.
+		qvlist.FormatQVOptionalFields(read);
+		qvlist.PrintQVOptionalFields(read, samFile);
+
+    samFile << endl;
+  }
 };
 
 

--- a/common/algorithms/alignment/printers/SAMPrinter.h
+++ b/common/algorithms/alignment/printers/SAMPrinter.h
@@ -496,10 +496,7 @@ namespace SAMOutput {
                       Clipping clipping = none,
                       int subreadIndex = 0,
                       int nSubreads = 0) {
-
-    string cigarString = "*";
     uint16_t flag = SEGMENT_UNMAPPED;
-
     T_Sequence alignedSequence;
     DNALength clippedReadLength = read.subreadEnd - read.subreadStart;
     DNALength clippedStartPos = read.subreadStart;

--- a/common/algorithms/alignment/printers/SAMPrinter.h
+++ b/common/algorithms/alignment/printers/SAMPrinter.h
@@ -492,7 +492,7 @@ namespace SAMOutput {
   void PrintUnalignedRead(T_Sequence &read,
                       ostream &samFile,
                       AlignmentContext &context,
-											SupplementalQVList &qvlist,
+                      SupplementalQVList &qvlist,
                       Clipping clipping = none,
                       int subreadIndex = 0,
                       int nSubreads = 0) {


### PR DESCRIPTION
Added a method to SAMOutput namespace to print unaligned reads when SAM output is requested.